### PR TITLE
Feature/toast

### DIFF
--- a/Examples/Toasts.rb
+++ b/Examples/Toasts.rb
@@ -1,0 +1,45 @@
+# Bootstrap the library
+require_relative "NxBootstrap.rb"
+
+# Toasts are small, transient informational dialogs.  They generally appear in the bottom left corner of an application
+# animate in, display for a short period, then animate out.
+
+java_import "com.nuix.nx.dialogs.Toast"
+java_import "java.awt.Rectangle"
+java_import "java.awt.Point"
+java_import "java.awt.Dimension"
+
+
+toast = Toast.new
+
+###
+# Display a Toast in a fixed position on screen (x = 1400, y = 1000)
+toast_size = Dimension.new 500, 80
+toast_location = Point.new 1400, 1000
+toast_bounds = Rectangle.new toast_location, toast_size
+
+toast.show_toast "Example Toast\n" +
+                   "This toast is in a fixed position on the screen,", toast_bounds
+
+# Wait a while so the previous toast goes away
+sleep 10
+
+###
+# This is a trick to get the toast to display in the bottom right corner of the Nuix Window.  It causes a brief
+# flicker in the UI.  It creates a new tab, gets screen coordinates, then closes that new tab.
+java_import "javax.swing.JPanel"
+tempView = JPanel.new
+window.addTab "Temp", tempView
+screen_location = tempView.location_on_screen
+screen_size = tempView.size
+tempView.parent.parent.close_selected_tab
+
+bottom = screen_location.y + screen_size.height
+right = screen_location.x + screen_size.width
+
+toast_size = Dimension.new 500, 80
+toast_location = Point.new right - toast_size.width, bottom - toast_size.height
+toast_bounds = Rectangle.new toast_location, toast_size
+
+toast.show_toast "Example Toast\n" +
+                   "This toast should be in the bottom right of th Workstation.", toast_bounds

--- a/Java/src/main/java/com/nuix/nx/dialogs/Toast.java
+++ b/Java/src/main/java/com/nuix/nx/dialogs/Toast.java
@@ -3,6 +3,8 @@ package com.nuix.nx.dialogs;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 public class Toast {
     private int toastTimeInSeconds = 5;
@@ -14,88 +16,108 @@ public class Toast {
 
     public String getLastMessage() { return lastMessage; }
 
-    public void showToast(String message, Rectangle position) {
+    public void showToast(String message, Rectangle targetPosition) {
+        if (targetPosition.x < 0 || targetPosition.y < 0)
+            throw new RuntimeException("Target position location must be >= 0");
+
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        if (targetPosition.x > (screenSize.width - targetPosition.width) ||
+            targetPosition.y > (screenSize.height - targetPosition.height))
+            throw new RuntimeException("Target position must not be off screen.");
+
         this.lastMessage = message;
-        this.lastPosition = position;
+        this.lastPosition = targetPosition;
 
         JWindow toastWindow = new JWindow();
         toastWindow.setBackground(new Color(0,0,0,0));
         toastWindow.setLayout(new FlowLayout());
 
-        JTextArea toastPainter2 = new JTextArea(position.height/11, position.width/11);
-        toastPainter2.setEditable(false);
+        // Get the size of the characters in the font, using "M" as a representative character for width
+        Font displayFont = new Font(Font.SERIF, Font.PLAIN, 12);
+        FontMetrics metrics = toastWindow.getFontMetrics(displayFont);
+        int fontHeight = metrics.getHeight();
+        int charWidth = metrics.charWidth('M');
+
+        int borderSize = 10;
+        // Create a Text Area - define the number of Rows and Columns to display based on the sized of the character
+        JTextArea toastPainter2 = new JTextArea((targetPosition.height-borderSize*2)/fontHeight,
+                (targetPosition.width-borderSize*2)/charWidth);
+
+        // Other text area configurations
         toastPainter2.setText(message);
-        toastPainter2.setBackground(Color.LIGHT_GRAY);
+        toastPainter2.setFont(displayFont);
+
+        toastPainter2.setEditable(false);
+        toastPainter2.setBackground(new Color(230, 230, 230));
         toastPainter2.setForeground(Color.BLACK);
-        toastPainter2.setBorder(new EmptyBorder(10, 10, 10, 10));
+        toastPainter2.setBorder(new EmptyBorder(borderSize, borderSize, borderSize, borderSize));
         toastPainter2.setOpaque(true);
         toastPainter2.setLineWrap(true);
         toastPainter2.setWrapStyleWord(true);
 
         toastWindow.add(toastPainter2);
-        toastWindow.setLocation(position.getLocation());
-        toastWindow.setSize(position.getSize());
 
-        animateIn(toastWindow);
+        // The expected size of the text display
+        Dimension painterSize = toastPainter2.getPreferredSize();
+        // Set the x position = the desired position + desired width - expected with
+        int displayX = (targetPosition.x + targetPosition.width) - painterSize.width;
+        Point startingPosition = new Point(displayX, screenSize.height);
 
-        try {
-            Thread.sleep(toastTimeInSeconds * 1000);
-        } catch (InterruptedException e) {
-            // Don't care;
-        }
+        toastWindow.setLocation(startingPosition);
+        toastWindow.setSize(painterSize);
 
-        animateOut(toastWindow);
+
+        toastWindow.setOpacity(1.0f);
+        toastWindow.setVisible(true);
+
+        Timer animateOutTask = new Timer(20, new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                toastWindow.setOpacity(toastWindow.getOpacity() - 0.04f);
+
+                if (toastWindow.getOpacity() < 0.04f) {
+                    toastWindow.setVisible(false);
+                    toastWindow.dispose();
+
+                    ((Timer)e.getSource()).stop();
+                }
+            }
+        });
+        animateOutTask.setRepeats(true);
+        animateOutTask.setInitialDelay(toastTimeInSeconds * 1000);
+
+
+        Timer animateInTask = new Timer(20, new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                Point currentPosition = toastWindow.getLocation();
+                Point newPosition = new Point(currentPosition.x, currentPosition.y - 5);
+                toastWindow.setLocation(newPosition);
+
+                if (newPosition.y <= targetPosition.y) {
+                    ((Timer)e.getSource()).stop();
+                    animateOutTask.start();
+                }
+            }
+        });
+        animateInTask.setRepeats(true);
+        animateInTask.setInitialDelay(0);
+        animateInTask.start();
     }
 
     public void showLastToast() {
         this.showToast(lastMessage, lastPosition);
     }
 
-    private void animateIn(JWindow window) {
-        try {
-            window.setOpacity(0.0f);
-            window.setVisible(true);
-            while (window.getOpacity() < 1.0) {
-                window.setOpacity(window.getOpacity() + 0.2f);
-                try {
-                    Thread.sleep(50);
-                } catch (InterruptedException e) {
-                    // Don't care
-                }
-            }
-        } finally {
-            window.setOpacity(1.0f);
-        }
-    }
-
-    private void animateOut(JWindow window) {
-        try {
-            while(window.getOpacity() > 0.2) {
-                window.setOpacity(window.getOpacity() - 0.2f);
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    // Don't care
-                }
-            }
-        } finally {
-            window.setVisible(false);
-            window.dispose();
-        }
-    }
-
     public static void main(String[] args) {
-        System.out.println("Starting");
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-        System.out.println(screenSize);
         Dimension toastSize = new Dimension(500, 80);
         Point location = new Point(screenSize.width - toastSize.width, screenSize.height - toastSize.height - 40);
         Rectangle bounds = new Rectangle(location, toastSize);
-        System.out.println(bounds);
+
         new Toast().showToast("Nuix T3K Analysis\n" +
                 "Your license for the application is about to expire.  Your last day of use is " +
                 "2023-01-28.  Please contact your sales representative to extend it.",
                 bounds);
-        System.out.println("Done");
     }
 }

--- a/Java/src/main/java/com/nuix/nx/dialogs/Toast.java
+++ b/Java/src/main/java/com/nuix/nx/dialogs/Toast.java
@@ -29,7 +29,7 @@ import java.awt.event.ActionListener;
  *
  *         String message = "Title\nThis is a brief message about something, but no worries, won't kill the application.";
  *         Rectangle position = new Rectangle(1400, 1000, 500, 80);
- *         toast.showMessage(message, position);
+ *         toast.showToast(message, position);
  * </pre>
  * <p>
  *     TODO: I have found the threading can cause slower than expected motion when the computer is under heavy load.

--- a/Java/src/main/java/com/nuix/nx/dialogs/Toast.java
+++ b/Java/src/main/java/com/nuix/nx/dialogs/Toast.java
@@ -6,16 +6,73 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+/**
+ * A Toast is a short-lived informational message displayed in the UI.
+ * <p>
+ *     Generally, Toasts are displayed in the bottom right corner of the UI - either the screen or the window.  They
+ *     are meant for non-critical information display not required by the current user workflow.  For example if a
+ *     licenses was about to expire, a Toast might be used to display the time left until expiration.
+ * </p>
+ * <p>
+ *     This Toast class represents a reusable container that can display text in a user-defined position on the screen.
+ *     Although the only limits to the position are that they must be fully on-screen, it will be generally useful to
+ *     ensure it is positions towards the bottom of the display as the Toast will animate on screen from below.  This
+ *     Toast will have an in-animation that moves the message into view from off the bottom of the screen and an out-
+ *     animation that fades the screen out.  Animations are handled in a thread to avoid blocking the UI or scripting
+ *     thread context
+ * </p>
+ * <p>
+ *     Use the {@link #showToast(String, Rectangle)} method to display the message in the location of interest:
+ * </p>
+ * <pre>
+ *         Toast toast = new Toast();
+ *
+ *         String message = "Title\nThis is a brief message about something, but no worries, won't kill the application.";
+ *         Rectangle position = new Rectangle(1400, 1000, 500, 80);
+ *         toast.showMessage(message, position);
+ * </pre>
+ * <p>
+ *     TODO: I have found the threading can cause slower than expected motion when the computer is under heavy load.
+ * </p>
+ */
 public class Toast {
     private int toastTimeInSeconds = 5;
     private String lastMessage = "";
     private Rectangle lastPosition = new Rectangle(0,0,0,0);
 
+    /**
+     * @param seconds The period of time, in seconds, the Toast should remain on screen after the in-animation
+     *                completes and before the out-animation starts.  The full time on screen will be longer than this
+     *                as the animation runs.  Defaults to 5 seconds if not set.
+     */
     public void setToastTimeInSeconds(int seconds) { toastTimeInSeconds = seconds; }
+
+    /**
+     * @return The period of time, in seconds, the Toast will be displayed on screen after it reaches its destination
+     * and before it begins to fade out.  The actual time on screen will be longer than this as the animations run.
+     */
     public int getToastTimeInSeconds() { return toastTimeInSeconds; }
 
+    /**
+     * @return The string contents of the last message sent to the Toast
+     */
     public String getLastMessage() { return lastMessage; }
 
+    /**
+     * Display the provided message at the position specified.
+     * <p>
+     *     When this method is called, the Toast will be created and animate in by sliding up to the desired position
+     *     from off the bottom of the screen.  Once in position it holds for several seconds then fades away.
+     *     This tool does not manage the display of multiple toasts at one time.
+     * </p>
+     * @param message A message to display.  The message can be multi-line, can include line breaks (\n) and will word
+     *                wrap.
+     * @param targetPosition A {@link Rectangle} defining the location and size of the box to display the message in.
+     *                       The location is relative to the top left of the screen (not window).  The width will be
+     *                       fixed at the defined size, and the height will be maximized at the defined size (but
+     *                       could be smaller if the message wouldn't fill the area).
+     * @throws RuntimeException if the target position is illegal, such as fully or partially off-screen.
+     */
     public void showToast(String message, Rectangle targetPosition) {
         if (targetPosition.x < 0 || targetPosition.y < 0)
             throw new RuntimeException("Target position location must be >= 0");
@@ -40,25 +97,25 @@ public class Toast {
 
         int borderSize = 10;
         // Create a Text Area - define the number of Rows and Columns to display based on the sized of the character
-        JTextArea toastPainter2 = new JTextArea((targetPosition.height-borderSize*2)/fontHeight,
+        JTextArea toastPainter = new JTextArea((targetPosition.height-borderSize*2)/fontHeight,
                 (targetPosition.width-borderSize*2)/charWidth);
 
         // Other text area configurations
-        toastPainter2.setText(message);
-        toastPainter2.setFont(displayFont);
+        toastPainter.setText(message);
+        toastPainter.setFont(displayFont);
 
-        toastPainter2.setEditable(false);
-        toastPainter2.setBackground(new Color(230, 230, 230));
-        toastPainter2.setForeground(Color.BLACK);
-        toastPainter2.setBorder(new EmptyBorder(borderSize, borderSize, borderSize, borderSize));
-        toastPainter2.setOpaque(true);
-        toastPainter2.setLineWrap(true);
-        toastPainter2.setWrapStyleWord(true);
+        toastPainter.setEditable(false);
+        toastPainter.setBackground(new Color(230, 230, 230));
+        toastPainter.setForeground(Color.BLACK);
+        toastPainter.setBorder(new EmptyBorder(borderSize, borderSize, borderSize, borderSize));
+        toastPainter.setOpaque(true);
+        toastPainter.setLineWrap(true);
+        toastPainter.setWrapStyleWord(true);
 
-        toastWindow.add(toastPainter2);
+        toastWindow.add(toastPainter);
 
         // The expected size of the text display
-        Dimension painterSize = toastPainter2.getPreferredSize();
+        Dimension painterSize = toastPainter.getPreferredSize();
         // Set the x position = the desired position + desired width - expected with
         int displayX = (targetPosition.x + targetPosition.width) - painterSize.width;
         Point startingPosition = new Point(displayX, screenSize.height);
@@ -105,19 +162,10 @@ public class Toast {
         animateInTask.start();
     }
 
+    /**
+     * Reshow the last message that was displayed, in the same location it was displayed in.
+     */
     public void showLastToast() {
         this.showToast(lastMessage, lastPosition);
-    }
-
-    public static void main(String[] args) {
-        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-        Dimension toastSize = new Dimension(500, 80);
-        Point location = new Point(screenSize.width - toastSize.width, screenSize.height - toastSize.height - 40);
-        Rectangle bounds = new Rectangle(location, toastSize);
-
-        new Toast().showToast("Nuix T3K Analysis\n" +
-                "Your license for the application is about to expire.  Your last day of use is " +
-                "2023-01-28.  Please contact your sales representative to extend it.",
-                bounds);
     }
 }

--- a/Java/src/main/java/com/nuix/nx/dialogs/Toast.java
+++ b/Java/src/main/java/com/nuix/nx/dialogs/Toast.java
@@ -1,0 +1,101 @@
+package com.nuix.nx.dialogs;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+
+public class Toast {
+    private int toastTimeInSeconds = 5;
+    private String lastMessage = "";
+    private Rectangle lastPosition = new Rectangle(0,0,0,0);
+
+    public void setToastTimeInSeconds(int seconds) { toastTimeInSeconds = seconds; }
+    public int getToastTimeInSeconds() { return toastTimeInSeconds; }
+
+    public String getLastMessage() { return lastMessage; }
+
+    public void showToast(String message, Rectangle position) {
+        this.lastMessage = message;
+        this.lastPosition = position;
+
+        JWindow toastWindow = new JWindow();
+        toastWindow.setBackground(new Color(0,0,0,0));
+        toastWindow.setLayout(new FlowLayout());
+
+        JTextArea toastPainter2 = new JTextArea(position.height/11, position.width/11);
+        toastPainter2.setEditable(false);
+        toastPainter2.setText(message);
+        toastPainter2.setBackground(Color.LIGHT_GRAY);
+        toastPainter2.setForeground(Color.BLACK);
+        toastPainter2.setBorder(new EmptyBorder(10, 10, 10, 10));
+        toastPainter2.setOpaque(true);
+        toastPainter2.setLineWrap(true);
+        toastPainter2.setWrapStyleWord(true);
+
+        toastWindow.add(toastPainter2);
+        toastWindow.setLocation(position.getLocation());
+        toastWindow.setSize(position.getSize());
+
+        animateIn(toastWindow);
+
+        try {
+            Thread.sleep(toastTimeInSeconds * 1000);
+        } catch (InterruptedException e) {
+            // Don't care;
+        }
+
+        animateOut(toastWindow);
+    }
+
+    public void showLastToast() {
+        this.showToast(lastMessage, lastPosition);
+    }
+
+    private void animateIn(JWindow window) {
+        try {
+            window.setOpacity(0.0f);
+            window.setVisible(true);
+            while (window.getOpacity() < 1.0) {
+                window.setOpacity(window.getOpacity() + 0.2f);
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    // Don't care
+                }
+            }
+        } finally {
+            window.setOpacity(1.0f);
+        }
+    }
+
+    private void animateOut(JWindow window) {
+        try {
+            while(window.getOpacity() > 0.2) {
+                window.setOpacity(window.getOpacity() - 0.2f);
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    // Don't care
+                }
+            }
+        } finally {
+            window.setVisible(false);
+            window.dispose();
+        }
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Starting");
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        System.out.println(screenSize);
+        Dimension toastSize = new Dimension(500, 80);
+        Point location = new Point(screenSize.width - toastSize.width, screenSize.height - toastSize.height - 40);
+        Rectangle bounds = new Rectangle(location, toastSize);
+        System.out.println(bounds);
+        new Toast().showToast("Nuix T3K Analysis\n" +
+                "Your license for the application is about to expire.  Your last day of use is " +
+                "2023-01-28.  Please contact your sales representative to extend it.",
+                bounds);
+        System.out.println("Done");
+    }
+}


### PR DESCRIPTION
Add a Toast message.

A toast is a short lived informational message.  It will animate on screen, display for a short period of time, and then animate off.  It is meant to be non-invasive and display non-critical information usually perpendicular to the task at hand (such as the availability of update, license ending soon, etc...).

There is a lot to improve this over time.  My wishlist would be (in no particular order):
1) Better and more options for animating on/off
2) Toast manager to handle multiple toasts
3) Manage disiplaying recent toasts in a permanent way
4) Hover effect that delays the out animation until the mouse leaves
5) Close button to exit the toast without waiting and without the out animation
6) Let the Toast handle location placement or have a default location placement relative to the Nuix Window
7) Create a fixed time for the in-animation (move faster if traveling farther for example)
8) How can we keep the animation off the UI thread but still smooth under heavy computer load?
9) UI cleanup - kind of boring display, this is part of the design (not supposed to be invasive) but could be nicer looking - maybe an icon, bolded title, or similar.